### PR TITLE
Correcting topology.json

### DIFF
--- a/pipelines/live/topologies/cvr-with-httpExtension-and-objectTracking/topology.json
+++ b/pipelines/live/topologies/cvr-with-httpExtension-and-objectTracking/topology.json
@@ -119,7 +119,7 @@
           "hubOutputName": "${hubSinkOutputName}",
           "inputs": [
             {
-              "nodeName": "httpExtension"
+              "nodeName": "objectTracker"
             }
           ]
         },


### PR DESCRIPTION
HTTP extension was the input to the IoT Hub Message Sink instead of the Object Tracker