### PR TITLE
(AzureCXP) Fixes MicrosoftDocs/azure-docs#77533

### DIFF
--- a/setup/prepare-device.sh
+++ b/setup/prepare-device.sh
@@ -40,7 +40,7 @@ sudo chown -R localedgeuser:localedgegroup /var/lib/videoanalyzer/
 sudo mkdir -p /var/lib/videoanalyzer/tmp/ 
 sudo chown -R localedgeuser:localedgegroup /var/lib/videoanalyzer/tmp/
 sudo mkdir -p /var/lib/videoanalyzer/logs
-sudo chown -R /localedgeuser:localedgegroup /var/lib/videoanalyzer/logs
+sudo chown -R localedgeuser:localedgegroup /var/lib/videoanalyzer/logs
 
 # output folder for file sink
 sudo mkdir -p /var/media


### PR DESCRIPTION
Correct chown command; Remove extra `/`

Reference: https://github.com/MicrosoftDocs/azure-docs/issues/77533