### PR TITLE
Changing video names to meet new limitation

### DIFF
--- a/pipelines/live/topologies/cvr-with-httpExtension-and-objectTracking/topology.json
+++ b/pipelines/live/topologies/cvr-with-httpExtension-and-objectTracking/topology.json
@@ -126,7 +126,7 @@
         {
           "@type": "#Microsoft.VideoAnalyzer.VideoSink",
           "name": "videoSink",
-          "videoName": "sample-cvr-with-inference-metadata",
+          "videoName": "sample-cvr-inference-metadata",
           "inputs": [
             {
               "nodeName": "rtspSource",

--- a/pipelines/live/topologies/motion-with-grpcExtension/topology.json
+++ b/pipelines/live/topologies/motion-with-grpcExtension/topology.json
@@ -181,7 +181,7 @@
       {
         "@type": "#Microsoft.VideoAnalyzer.VideoSink",
         "name": "videoSink",
-        "videoName": "sample-motion-with-grpc-extension",
+        "videoName": "sample-motion-grpc-extension",
         "inputs": [
           {
             "nodeName": "signalGateProcessor",

--- a/pipelines/live/topologies/motion-with-httpExtension/topology.json
+++ b/pipelines/live/topologies/motion-with-httpExtension/topology.json
@@ -158,7 +158,7 @@
       {
         "@type": "#Microsoft.VideoAnalyzer.VideoSink",
         "name": "videoSink",
-        "videoName": "sample-motion-with-http-extension",
+        "videoName": "sample-motion-http-extension",
         "inputs": [
           {
             "nodeName": "signalGateProcessor",

--- a/pipelines/live/topologies/spatial-analysis/custom-operation-topology.json
+++ b/pipelines/live/topologies/spatial-analysis/custom-operation-topology.json
@@ -131,7 +131,7 @@
         {
           "@type": "#Microsoft.VideoAnalyzer.VideoSink",
           "name": "videoSink",
-          "videoName": "Ignite-Spatial-Analysis-${System.TopologyName}",
+          "videoName": "SA-${System.TopologyName}",
           "inputs": [
             {
               "nodeName": "signalGateProcessor"


### PR DESCRIPTION
VideoSink->VideoName should only contain A-Z, a-z, or hyphens. It should also be less or equal to 32 characters.

The video names changed in these topologies were greater than 32 characters.